### PR TITLE
Make the CDI/interceptor dependencies optional in module-info

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 module jakarta.transaction {
     requires java.rmi;
     requires transitive java.transaction.xa;
-    requires transitive jakarta.cdi;
-    requires jakarta.interceptor;
+    requires static transitive jakarta.cdi;
+    requires static jakarta.interceptor;
 
     exports jakarta.transaction;
 }


### PR DESCRIPTION
Fixes #214 

The "static" keyword means "required for compilation of this module, but not at runtime", which is pretty much the current situation.

Those dependencies are only required for the `@Transactional` and `@TransactionScoped` annotations,
but jakarta.transaction-api can perfectly well be used without CDI, e.g. in Hibernate ORM in a Java SE environment.

Without this change, it's impossible to use jakarta.transaction-api (or anything relying on it, e.g. Hibernate ORM) without CDI in the modulepath.