### PR TITLE
Formatter and formatting changes

### DIFF
--- a/api/etc/config/copyright-eclipse.txt
+++ b/api/etc/config/copyright-eclipse.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) YYYY Contributors to the Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+ 

--- a/api/etc/config/copyright-exclude
+++ b/api/etc/config/copyright-exclude
@@ -1,0 +1,8 @@
+.dtd
+.png
+.xsd
+ee4j-eclipse-formatting.xml
+speclicense.html
+/etc/config/copyright-exclude
+/etc/config/copyright-eclipse.txt
+/etc/config/copyright-oracle.txt

--- a/api/etc/config/copyright-oracle.txt
+++ b/api/etc/config/copyright-oracle.txt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) YYYY Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+

--- a/api/etc/config/ee4j-eclipse-formatting.xml
+++ b/api/etc/config/ee4j-eclipse-formatting.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="14">
+<profile kind="CodeFormatterProfile" name="EE4J" version="14">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="160"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -100,7 +100,24 @@
             <resource>
                 <directory>src/main/resources</directory>
             </resource>
-        </resources>        
+        </resources>   
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>2.26.0</version>
+                    <configuration>
+                        <configFile>${project.basedir}/etc/config/ee4j-eclipse-formatting.xml</configFile>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>1.12.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>     
         <plugins>
             <!--
             Use the JDK 11+ compiler but with -source 1.8 for all
@@ -312,6 +329,89 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>validate</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>check-imports</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/api/src/main/java/jakarta/transaction/HeuristicCommitException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicCommitException.java
@@ -17,27 +17,22 @@
 package jakarta.transaction;
 
 /**
- * This exception is thrown by the rollback operation on a resource to
- * report that a heuristic decision was made and that all relevant updates
- * have been committed.
+ * This exception is thrown by the rollback operation on a resource to report that a heuristic decision was made and
+ * that all relevant updates have been committed.
  *
  * @version Jakarta Transactions 2.0
  */
-public class HeuristicCommitException extends java.lang.Exception  
-{
+public class HeuristicCommitException extends java.lang.Exception {
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = -3977609782149921760L;
-    
-    public HeuristicCommitException()
-    {
-	super();
+
+    public HeuristicCommitException() {
+        super();
     }
 
-    public HeuristicCommitException(String msg)
-    {
-	super(msg);
+    public HeuristicCommitException(String msg) {
+        super(msg);
     }
 }
-

--- a/api/src/main/java/jakarta/transaction/HeuristicMixedException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicMixedException.java
@@ -17,27 +17,22 @@
 package jakarta.transaction;
 
 /**
- * This exception is thrown to report that a heuristic decision was made and
- * that some relevant updates have been committed and others have been
- * rolled back.
+ * This exception is thrown to report that a heuristic decision was made and that some relevant updates have been
+ * committed and others have been rolled back.
  *
  * @version Jakarta Transactions 2.0
  */
-public class HeuristicMixedException extends java.lang.Exception  
-{
+public class HeuristicMixedException extends java.lang.Exception {
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = 2345014349685956666L;
 
-    public HeuristicMixedException()
-    {
-	super();
+    public HeuristicMixedException() {
+        super();
     }
 
-    public HeuristicMixedException(String msg)
-    {
-	super(msg);
+    public HeuristicMixedException(String msg) {
+        super(msg);
     }
 }
-

--- a/api/src/main/java/jakarta/transaction/HeuristicRollbackException.java
+++ b/api/src/main/java/jakarta/transaction/HeuristicRollbackException.java
@@ -17,26 +17,22 @@
 package jakarta.transaction;
 
 /**
- * This exception is thrown by the commit operation to report that a heuristic
- * decision was made and that all relevant updates have been rolled back.
+ * This exception is thrown by the commit operation to report that a heuristic decision was made and that all relevant
+ * updates have been rolled back.
  *
  * @version Jakarta Transactions 2.0
  */
-public class HeuristicRollbackException extends java.lang.Exception 
-{
+public class HeuristicRollbackException extends java.lang.Exception {
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = -3483618944556408897L;
 
-    public HeuristicRollbackException()
-    {
-	super();
+    public HeuristicRollbackException() {
+        super();
     }
 
-    public HeuristicRollbackException(String msg)
-    {
-	super(msg);
+    public HeuristicRollbackException(String msg) {
+        super(msg);
     }
 }
-

--- a/api/src/main/java/jakarta/transaction/InvalidTransactionException.java
+++ b/api/src/main/java/jakarta/transaction/InvalidTransactionException.java
@@ -17,27 +17,22 @@
 package jakarta.transaction;
 
 /**
- * This exception indicates that the request carried an invalid transaction
- * context. For example, this exception could be raised if an error
- * occurred when trying to register a resource.
+ * This exception indicates that the request carried an invalid transaction context. For example, this exception could
+ * be raised if an error occurred when trying to register a resource.
  *
  * @version Jakarta Transactions 2.0
  */
-public class InvalidTransactionException extends java.rmi.RemoteException 
-{
+public class InvalidTransactionException extends java.rmi.RemoteException {
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = 3597320220337691496L;
 
-    public InvalidTransactionException()
-	{
-		super();
-	}
+    public InvalidTransactionException() {
+        super();
+    }
 
-	public InvalidTransactionException(String msg)
-	{
-		super(msg);
-	}
+    public InvalidTransactionException(String msg) {
+        super(msg);
+    }
 }
-

--- a/api/src/main/java/jakarta/transaction/NotSupportedException.java
+++ b/api/src/main/java/jakarta/transaction/NotSupportedException.java
@@ -17,32 +17,25 @@
 package jakarta.transaction;
 
 /**
- * NotSupportedException exception indicates that the request cannot be
- * executed because the operation is not a supported feature. For example, 
- * because nested transactions are not supported, the Transaction Manager 
- * throws this exception when a calling thread
- * that is already associated with a transaction attempts to start a new 
- * transaction. (A nested transaction occurs when a thread is already
- * associated with one transaction and attempts to start a second 
+ * NotSupportedException exception indicates that the request cannot be executed because the operation is not a
+ * supported feature. For example, because nested transactions are not supported, the Transaction Manager throws this
+ * exception when a calling thread that is already associated with a transaction attempts to start a new transaction. (A
+ * nested transaction occurs when a thread is already associated with one transaction and attempts to start a second
  * transaction.)
  *
  * @version Jakarta Transactions 2.0
  */
-public class NotSupportedException extends java.lang.Exception 
-{
-        /**
-         * Specify serialVersionUID for backward compatibility
-         */
-        private static final long serialVersionUID = 56870312332816390L;
+public class NotSupportedException extends java.lang.Exception {
+    /**
+     * Specify serialVersionUID for backward compatibility
+     */
+    private static final long serialVersionUID = 56870312332816390L;
 
-        public NotSupportedException()
-	{
-		super();
-	}
+    public NotSupportedException() {
+        super();
+    }
 
-	public NotSupportedException(String msg)
-	{
-		super(msg);
-	}
+    public NotSupportedException(String msg) {
+        super(msg);
+    }
 }
-

--- a/api/src/main/java/jakarta/transaction/RollbackException.java
+++ b/api/src/main/java/jakarta/transaction/RollbackException.java
@@ -17,29 +17,23 @@
 package jakarta.transaction;
 
 /**
- * RollbackException exception is thrown when the transaction has been 
- * marked for rollback only or the transaction has been rolled back
- * instead of committed. This is a local exception thrown by methods 
- * in the <code>UserTransaction</code>, <code>Transaction</code>, and 
- * <code>TransactionManager</code> interfaces.
+ * RollbackException exception is thrown when the transaction has been marked for rollback only or the transaction has
+ * been rolled back instead of committed. This is a local exception thrown by methods in the
+ * <code>UserTransaction</code>, <code>Transaction</code>, and <code>TransactionManager</code> interfaces.
  *
  * @version Jakarta Transactions 2.0
  */
-public class RollbackException extends java.lang.Exception 
-{
-        /**
-         * Specify serialVersionUID for backward compatibility
-         */
-        private static final long serialVersionUID = 4151607774785285395L;
-        
-	public RollbackException()
-	{
-		super();
-	}
+public class RollbackException extends java.lang.Exception {
+    /**
+     * Specify serialVersionUID for backward compatibility
+     */
+    private static final long serialVersionUID = 4151607774785285395L;
 
-	public RollbackException(String msg)
-	{
-		super(msg);
-	}
+    public RollbackException() {
+        super();
+    }
+
+    public RollbackException(String msg) {
+        super(msg);
+    }
 }
-

--- a/api/src/main/java/jakarta/transaction/Status.java
+++ b/api/src/main/java/jakarta/transaction/Status.java
@@ -17,88 +17,72 @@
 package jakarta.transaction;
 
 /**
- * The Status interface defines static variables used for transaction 
- * status codes.
+ * The Status interface defines static variables used for transaction status codes.
  *
  * @version Jakarta Transactions 2.0
  */
 
 public interface Status {
     /**
-     * A transaction is associated with the target object and it is in the
-     * active state. An implementation returns this status after a
-     * transaction has been started and prior to a Coordinator issuing
-     * any prepares, unless the transaction has been marked for rollback.
-     */  
+     * A transaction is associated with the target object and it is in the active state. An implementation returns this
+     * status after a transaction has been started and prior to a Coordinator issuing any prepares, unless the transaction
+     * has been marked for rollback.
+     */
     public final static int STATUS_ACTIVE = 0;
 
     /**
-     * A transaction is associated with the target object and it has been
-     * marked for rollback, perhaps as a result of a setRollbackOnly operation.
-     */  
+     * A transaction is associated with the target object and it has been marked for rollback, perhaps as a result of a
+     * setRollbackOnly operation.
+     */
     public final static int STATUS_MARKED_ROLLBACK = 1;
 
     /**
-     * A transaction is associated with the target object and it has been
-     * prepared. That is, all subordinates have agreed to commit. The
-     * target object may be waiting for instructions from a superior as to how
-     * to proceed.
-     */  
+     * A transaction is associated with the target object and it has been prepared. That is, all subordinates have agreed to
+     * commit. The target object may be waiting for instructions from a superior as to how to proceed.
+     */
     public final static int STATUS_PREPARED = 2;
- 
+
     /**
-     * A transaction is associated with the target object and it has been
-     * committed. It is likely that heuristics exist; otherwise, the
-     * transaction would have been destroyed and NoTransaction returned.
-     */  
+     * A transaction is associated with the target object and it has been committed. It is likely that heuristics exist;
+     * otherwise, the transaction would have been destroyed and NoTransaction returned.
+     */
     public final static int STATUS_COMMITTED = 3;
 
     /**
-     * A transaction is associated with the target object and the outcome
-     * has been determined to be rollback. It is likely that heuristics exist;
-     * otherwise, the transaction would have been destroyed and NoTransaction
-     * returned.
-     */  
+     * A transaction is associated with the target object and the outcome has been determined to be rollback. It is likely
+     * that heuristics exist; otherwise, the transaction would have been destroyed and NoTransaction returned.
+     */
     public final static int STATUS_ROLLEDBACK = 4;
 
     /**
-     * A transaction is associated with the target object but its
-     * current status cannot be determined. This is a transient condition
-     * and a subsequent invocation will ultimately return a different status.
-     */  
+     * A transaction is associated with the target object but its current status cannot be determined. This is a transient
+     * condition and a subsequent invocation will ultimately return a different status.
+     */
     public final static int STATUS_UNKNOWN = 5;
 
     /**
-     * No transaction is currently associated with the target object. This
-     * will occur after a transaction has completed.
-     */  
+     * No transaction is currently associated with the target object. This will occur after a transaction has completed.
+     */
     public final static int STATUS_NO_TRANSACTION = 6;
 
     /**
-     * A transaction is associated with the target object and it is in the
-     * process of preparing. An implementation returns this status if it
-     * has started preparing, but has not yet completed the process. The
-     * likely reason for this is that the implementation is probably
-     * waiting for responses to prepare from one or more
-     * Resources.
-     */  
+     * A transaction is associated with the target object and it is in the process of preparing. An implementation returns
+     * this status if it has started preparing, but has not yet completed the process. The likely reason for this is that
+     * the implementation is probably waiting for responses to prepare from one or more Resources.
+     */
     public final static int STATUS_PREPARING = 7;
 
     /**
-     * A transaction is associated with the target object and it is in the
-     * process of committing. An implementation returns this status if it
-     * has decided to commit but has not yet completed the committing process. 
-     * This occurs because the implementation is probably waiting for 
-     * responses from one or more Resources.
-     */  
+     * A transaction is associated with the target object and it is in the process of committing. An implementation returns
+     * this status if it has decided to commit but has not yet completed the committing process. This occurs because the
+     * implementation is probably waiting for responses from one or more Resources.
+     */
     public final static int STATUS_COMMITTING = 8;
 
     /**
-     * A transaction is associated with the target object and it is in the
-     * process of rolling back. An implementation returns this status if
-     * it has decided to rollback but has not yet completed the process.
-     * The implementation is probably waiting for responses from one or more
-     * Resources.
-     */  
+     * A transaction is associated with the target object and it is in the process of rolling back. An implementation
+     * returns this status if it has decided to rollback but has not yet completed the process. The implementation is
+     * probably waiting for responses from one or more Resources.
+     */
     public final static int STATUS_ROLLING_BACK = 9;
 }

--- a/api/src/main/java/jakarta/transaction/Synchronization.java
+++ b/api/src/main/java/jakarta/transaction/Synchronization.java
@@ -17,30 +17,24 @@
 package jakarta.transaction;
 
 /**
- * The transaction manager supports a synchronization mechanism
- * that allows the interested party to be notified before and
- * after the transaction completes. Using the registerSynchronization
- * method, the application server registers a Synchronization object
- * for the transaction currently associated with the target Transaction
- * object.
+ * The transaction manager supports a synchronization mechanism that allows the interested party to be notified before
+ * and after the transaction completes. Using the registerSynchronization method, the application server registers a
+ * Synchronization object for the transaction currently associated with the target Transaction object.
  *
  * @version Jakarta Transactions 2.0
  */
 public interface Synchronization {
 
     /**
-     * The beforeCompletion method is called by the transaction manager prior
-     * to the start of the two-phase transaction commit process. This call is
-     * executed with the transaction context of the transaction that is being
-     * committed.
+     * The beforeCompletion method is called by the transaction manager prior to the start of the two-phase transaction
+     * commit process. This call is executed with the transaction context of the transaction that is being committed.
      */
     public void beforeCompletion();
 
     /**
-     * This method is called by the transaction
-     * manager after the transaction is committed or rolled back.
+     * This method is called by the transaction manager after the transaction is committed or rolled back.
      *
      * @param status The status of the transaction completion.
      */
-	public void afterCompletion(int status);
+    public void afterCompletion(int status);
 }

--- a/api/src/main/java/jakarta/transaction/SystemException.java
+++ b/api/src/main/java/jakarta/transaction/SystemException.java
@@ -17,9 +17,8 @@
 package jakarta.transaction;
 
 /**
- * The SystemException is thrown by the transaction manager to 
- * indicate that it has encountered an unexpected error condition
- * that prevents future transaction services from proceeding.
+ * The SystemException is thrown by the transaction manager to indicate that it has encountered an unexpected error
+ * condition that prevents future transaction services from proceeding.
  *
  * @version Jakarta Transactions 2.0
  */
@@ -37,31 +36,27 @@ public class SystemException extends java.lang.Exception {
      */
     public int errorCode;
 
-    public SystemException()
-    {
-    	super();
-    }    
-    
+    public SystemException() {
+        super();
+    }
+
     /**
      * Create a SystemException with a given string.
      *
      * @param s The string message for the exception
      */
-    public SystemException(String s)
-    {
-    	super(s);
+    public SystemException(String s) {
+        super(s);
     }
-    
+
     /**
      * Create a SystemException with a given error code.
      *
      * @param errcode The error code for the exception
      */
-    public SystemException(int errcode)
-    {
-    	super();
-    	errorCode = errcode;
+    public SystemException(int errcode) {
+        super();
+        errorCode = errcode;
     }
-
 
 }

--- a/api/src/main/java/jakarta/transaction/Transaction.java
+++ b/api/src/main/java/jakarta/transaction/Transaction.java
@@ -16,17 +16,14 @@
 
 package jakarta.transaction;
 
-import javax.transaction.xa.XAResource;
 import java.lang.IllegalStateException;
 import java.lang.SecurityException;
+import javax.transaction.xa.XAResource;
 
 /**
- * The Transaction interface allows operations to be performed against
- * the transaction in the target Transaction object. A Transaction
- * object is created corresponding to each global transaction creation.
- * The Transaction object can be used for resource enlistment,
- * synchronization registration, transaction completion, and status
- * query operations.
+ * The Transaction interface allows operations to be performed against the transaction in the target Transaction object.
+ * A Transaction object is created corresponding to each global transaction creation. The Transaction object can be used
+ * for resource enlistment, synchronization registration, transaction completion, and status query operations.
  *
  * @version Jakarta Transactions 2.0
  */
@@ -36,142 +33,111 @@ public interface Transaction {
     /**
      * Complete the transaction represented by this Transaction object.
      *
-     * @exception RollbackException Thrown to indicate that
-     *    the transaction has been rolled back rather than committed.
+     * @exception RollbackException Thrown to indicate that the transaction has been rolled back rather than committed.
      *
-     * @exception HeuristicMixedException Thrown to indicate that a heuristic
-     *    decision was made and that some relevant updates have been committed
-     *    while others have been rolled back.
+     * @exception HeuristicMixedException Thrown to indicate that a heuristic decision was made and that some relevant
+     * updates have been committed while others have been rolled back.
      *
-     * @exception HeuristicRollbackException Thrown to indicate that a
-     *    heuristic decision was made and that all relevant updates have been
-     *    rolled back.
+     * @exception HeuristicRollbackException Thrown to indicate that a heuristic decision was made and that all relevant
+     * updates have been rolled back.
      *
-     * @exception SecurityException Thrown to indicate that the thread is
-     *    not allowed to commit the transaction.
+     * @exception SecurityException Thrown to indicate that the thread is not allowed to commit the transaction.
      *
-     * @exception IllegalStateException Thrown if the transaction in the 
-     *    target object is inactive.
+     * @exception IllegalStateException Thrown if the transaction in the target object is inactive.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      */
     public void commit() throws RollbackException,
-                HeuristicMixedException, HeuristicRollbackException,
-                SecurityException, IllegalStateException, SystemException;
+            HeuristicMixedException, HeuristicRollbackException,
+            SecurityException, IllegalStateException, SystemException;
 
     /**
-     * Disassociate the resource specified from the transaction associated 
-     * with the target Transaction object.
+     * Disassociate the resource specified from the transaction associated with the target Transaction object.
      *
-     * @param xaRes The XAResource object associated with the resource 
-     *              (connection).
+     * @param xaRes The XAResource object associated with the resource (connection).
      *
      * @param flag One of the values of TMSUCCESS, TMSUSPEND, or TMFAIL.
      *
-     * @exception IllegalStateException Thrown if the transaction in the
-     *    target object is inactive.
+     * @exception IllegalStateException Thrown if the transaction in the target object is inactive.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
-     * @return <i>true</i> if the resource was delisted successfully; otherwise
-     *	  <i>false</i>.
+     * @return <i>true</i> if the resource was delisted successfully; otherwise <i>false</i>.
      *
      */
     public boolean delistResource(XAResource xaRes, int flag)
-        throws IllegalStateException, SystemException;
+            throws IllegalStateException, SystemException;
 
     /**
-     * Enlist the resource specified with the transaction associated with the 
-     * target Transaction object.
+     * Enlist the resource specified with the transaction associated with the target Transaction object.
      *
-     * @param xaRes The XAResource object associated with the resource 
-     *              (connection).
+     * @param xaRes The XAResource object associated with the resource (connection).
      *
-     * @return <i>true</i> if the resource was enlisted successfully; otherwise
-     *    <i>false</i>.
+     * @return <i>true</i> if the resource was enlisted successfully; otherwise <i>false</i>.
      *
-     * @exception RollbackException Thrown to indicate that
-     *    the transaction has been marked for rollback only.
+     * @exception RollbackException Thrown to indicate that the transaction has been marked for rollback only.
      *
-     * @exception IllegalStateException Thrown if the transaction in the
-     *    target object is in the prepared state or the transaction is
-     *    inactive.
+     * @exception IllegalStateException Thrown if the transaction in the target object is in the prepared state or the
+     * transaction is inactive.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public boolean enlistResource(XAResource xaRes)
-        throws RollbackException, IllegalStateException,
-        SystemException;
+            throws RollbackException, IllegalStateException,
+            SystemException;
 
     /**
-     * Obtain the status of the transaction associated with the target 
-     * Transaction object.
+     * Obtain the status of the transaction associated with the target Transaction object.
      *
-     * @return The transaction status. If no transaction is associated with
-     *    the target object, this method returns the 
-     *    Status.NoTransaction value.
+     * @return The transaction status. If no transaction is associated with the target object, this method returns the
+     * Status.NoTransaction value.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public int getStatus() throws SystemException;
 
     /**
-     * Register a synchronization object for the transaction currently
-     * associated with the target object. The transction manager invokes
-     * the beforeCompletion method prior to starting the two-phase transaction
-     * commit process. After the transaction is completed, the transaction
-     * manager invokes the afterCompletion method.
+     * Register a synchronization object for the transaction currently associated with the target object. The transction
+     * manager invokes the beforeCompletion method prior to starting the two-phase transaction commit process. After the
+     * transaction is completed, the transaction manager invokes the afterCompletion method.
      *
-     * @param sync The Synchronization object for the transaction associated
-     *    with the target object.
+     * @param sync The Synchronization object for the transaction associated with the target object.
      *
-     * @exception RollbackException Thrown to indicate that
-     *    the transaction has been marked for rollback only.
+     * @exception RollbackException Thrown to indicate that the transaction has been marked for rollback only.
      *
-     * @exception IllegalStateException Thrown if the transaction in the
-     *    target object is in the prepared state or the transaction is
-     *	  inactive.
+     * @exception IllegalStateException Thrown if the transaction in the target object is in the prepared state or the
+     * transaction is inactive.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void registerSynchronization(Synchronization sync)
-                throws RollbackException, IllegalStateException,
-                SystemException;
+            throws RollbackException, IllegalStateException,
+            SystemException;
 
     /**
      * Rollback the transaction represented by this Transaction object.
      *
-     * @exception IllegalStateException Thrown if the transaction in the
-     *    target object is in the prepared state or the transaction is
-     *    inactive.
+     * @exception IllegalStateException Thrown if the transaction in the target object is in the prepared state or the
+     * transaction is inactive.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
-	public void rollback() throws IllegalStateException, SystemException;
+    public void rollback() throws IllegalStateException, SystemException;
 
     /**
-     * Modify the transaction associated with the target object such that
-     * the only possible outcome of the transaction is to roll back the
-     * transaction.
+     * Modify the transaction associated with the target object such that the only possible outcome of the transaction is to
+     * roll back the transaction.
      *
-     * @exception IllegalStateException Thrown if the target object is
-     *    not associated with any transaction.
+     * @exception IllegalStateException Thrown if the target object is not associated with any transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void setRollbackOnly() throws IllegalStateException,
-        SystemException;
+            SystemException;
 
 }

--- a/api/src/main/java/jakarta/transaction/TransactionManager.java
+++ b/api/src/main/java/jakarta/transaction/TransactionManager.java
@@ -20,8 +20,8 @@ import java.lang.IllegalStateException;
 import java.lang.SecurityException;
 
 /**
- * The TransactionManager interface defines the methods that allow an
- * application server to manage transaction boundaries.
+ * The TransactionManager interface defines the methods that allow an application server to manage transaction
+ * boundaries.
  *
  * @version Jakarta Transactions 2.0
  */
@@ -30,154 +30,123 @@ public interface TransactionManager {
     /**
      * Create a new transaction and associate it with the current thread.
      *
-     * @exception NotSupportedException Thrown if the thread is already
-     *    associated with a transaction and the Transaction Manager
-     *    implementation does not support nested transactions.
+     * @exception NotSupportedException Thrown if the thread is already associated with a transaction and the Transaction
+     * Manager implementation does not support nested transactions.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void begin() throws NotSupportedException, SystemException;
 
     /**
-     * Complete the transaction associated with the current thread. When this
-     * method completes, the thread is no longer associated with a transaction.
+     * Complete the transaction associated with the current thread. When this method completes, the thread is no longer
+     * associated with a transaction.
      *
-     * @exception RollbackException Thrown to indicate that
-     *    the transaction has been rolled back rather than committed.
+     * @exception RollbackException Thrown to indicate that the transaction has been rolled back rather than committed.
      *
-     * @exception HeuristicMixedException Thrown to indicate that a heuristic
-     *    decision was made and that some relevant updates have been committed
-     *    while others have been rolled back.
+     * @exception HeuristicMixedException Thrown to indicate that a heuristic decision was made and that some relevant
+     * updates have been committed while others have been rolled back.
      *
-     * @exception HeuristicRollbackException Thrown to indicate that a
-     *    heuristic decision was made and that all relevant updates have been
-     *    rolled back.
+     * @exception HeuristicRollbackException Thrown to indicate that a heuristic decision was made and that all relevant
+     * updates have been rolled back.
      *
-     * @exception SecurityException Thrown to indicate that the thread is
-     *    not allowed to commit the transaction.
+     * @exception SecurityException Thrown to indicate that the thread is not allowed to commit the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void commit() throws RollbackException,
-	HeuristicMixedException, HeuristicRollbackException, SecurityException,
-	IllegalStateException, SystemException;
+            HeuristicMixedException, HeuristicRollbackException, SecurityException,
+            IllegalStateException, SystemException;
 
     /**
      * Obtain the status of the transaction associated with the current thread.
      *
-     * @return The transaction status. If no transaction is associated with
-     *    the current thread, this method returns the Status.NoTransaction
-     *    value.
+     * @return The transaction status. If no transaction is associated with the current thread, this method returns the
+     * Status.NoTransaction value.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public int getStatus() throws SystemException;
 
     /**
-     * Get the transaction object that represents the transaction
-     * context of the calling thread.
+     * Get the transaction object that represents the transaction context of the calling thread.
      *
-     * @return the <code>Transaction</code> object representing the
-     *	  transaction associated with the calling thread.
+     * @return the <code>Transaction</code> object representing the transaction associated with the calling thread.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public Transaction getTransaction() throws SystemException;
 
     /**
-     * Resume the transaction context association of the calling thread
-     * with the transaction represented by the supplied Transaction object.
-     * When this method returns, the calling thread is associated with the
-     * transaction context specified.
+     * Resume the transaction context association of the calling thread with the transaction represented by the supplied
+     * Transaction object. When this method returns, the calling thread is associated with the transaction context
+     * specified.
      *
-     * @param tobj The <code>Transaction</code> object that represents the
-     *    transaction to be resumed.
+     * @param tobj The <code>Transaction</code> object that represents the transaction to be resumed.
      *
-     * @exception InvalidTransactionException Thrown if the parameter
-     *    transaction object contains an invalid transaction.
+     * @exception InvalidTransactionException Thrown if the parameter transaction object contains an invalid transaction.
      *
-     * @exception IllegalStateException Thrown if the thread is already
-     *    associated with another transaction.
+     * @exception IllegalStateException Thrown if the thread is already associated with another transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      */
     public void resume(Transaction tobj)
             throws InvalidTransactionException, IllegalStateException,
             SystemException;
 
     /**
-     * Roll back the transaction associated with the current thread. When this
-     * method completes, the thread is no longer associated with a
-     * transaction.
+     * Roll back the transaction associated with the current thread. When this method completes, the thread is no longer
+     * associated with a transaction.
      *
-     * @exception SecurityException Thrown to indicate that the thread is
-     *    not allowed to roll back the transaction.
+     * @exception SecurityException Thrown to indicate that the thread is not allowed to roll back the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void rollback() throws IllegalStateException, SecurityException,
-                            SystemException;
+            SystemException;
 
     /**
-     * Modify the transaction associated with the current thread such that
-     * the only possible outcome of the transaction is to roll back the
-     * transaction.
+     * Modify the transaction associated with the current thread such that the only possible outcome of the transaction is
+     * to roll back the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void setRollbackOnly() throws IllegalStateException, SystemException;
 
     /**
-     * Modify the timeout value that is associated with transactions started
-     * by the current thread with the begin method.
+     * Modify the timeout value that is associated with transactions started by the current thread with the begin method.
      *
-     * <p> If an application has not called this method, the transaction
-     * service uses some default value for the transaction timeout.
+     * <p>
+     * If an application has not called this method, the transaction service uses some default value for the transaction
+     * timeout.
      *
-     * @param seconds The value of the timeout in seconds. If the value is zero,
-     *        the transaction service restores the default value. If the value
-     *        is negative a SystemException is thrown.
+     * @param seconds The value of the timeout in seconds. If the value is zero, the transaction service restores the
+     * default value. If the value is negative a SystemException is thrown.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public void setTransactionTimeout(int seconds) throws SystemException;
 
     /**
-     * Suspend the transaction currently associated with the calling
-     * thread and return a Transaction object that represents the
-     * transaction context being suspended. If the calling thread is
-     * not associated with a transaction, the method returns a null
-     * object reference. When this method returns, the calling thread
-     * is not associated with a transaction.
+     * Suspend the transaction currently associated with the calling thread and return a Transaction object that represents
+     * the transaction context being suspended. If the calling thread is not associated with a transaction, the method
+     * returns a null object reference. When this method returns, the calling thread is not associated with a transaction.
      *
      * @return Transaction object representing the suspended transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     public Transaction suspend() throws SystemException;

--- a/api/src/main/java/jakarta/transaction/TransactionRequiredException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionRequiredException.java
@@ -17,27 +17,23 @@
 package jakarta.transaction;
 
 /**
- * This exception indicates that a request carried a null transaction context,
- * but the target object requires an active transaction.
+ * This exception indicates that a request carried a null transaction context, but the target object requires an active
+ * transaction.
  *
  * @version Jakarta Transactions 2.0
  */
-public class TransactionRequiredException extends java.rmi.RemoteException 
-{
-	    
+public class TransactionRequiredException extends java.rmi.RemoteException {
+
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = -1898806419937446439L;
 
-        public TransactionRequiredException()
-	{
-		super();
-	}
+    public TransactionRequiredException() {
+        super();
+    }
 
-	public TransactionRequiredException(String msg)
-	{
-		super(msg);
-	}
+    public TransactionRequiredException(String msg) {
+        super(msg);
+    }
 }
-

--- a/api/src/main/java/jakarta/transaction/TransactionRolledbackException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionRolledbackException.java
@@ -17,30 +17,24 @@
 package jakarta.transaction;
 
 /**
- * This exception indicates that the transaction associated with processing
- * of the request has been rolled back, or it has been marked to roll back. 
- * Thus the requested operation either could not be performed or was not 
- * performed because further computation on behalf of the transaction would be
- * fruitless.
+ * This exception indicates that the transaction associated with processing of the request has been rolled back, or it
+ * has been marked to roll back. Thus the requested operation either could not be performed or was not performed because
+ * further computation on behalf of the transaction would be fruitless.
  *
  * @version Jakarta Transactions 2.0
  */
-public class TransactionRolledbackException extends java.rmi.RemoteException 
-{
-	    
+public class TransactionRolledbackException extends java.rmi.RemoteException {
+
     /**
      * Specify serialVersionUID for backward compatibility
      */
     private static final long serialVersionUID = -3142798139623020577L;
-    
-    public TransactionRolledbackException()
-	{
-		super();
-	}
 
-	public TransactionRolledbackException(String msg)
-	{
-		super(msg);
-	}
+    public TransactionRolledbackException() {
+        super();
+    }
+
+    public TransactionRolledbackException(String msg) {
+        super(msg);
+    }
 }
-

--- a/api/src/main/java/jakarta/transaction/TransactionScoped.java
+++ b/api/src/main/java/jakarta/transaction/TransactionScoped.java
@@ -16,22 +16,20 @@
 
 package jakarta.transaction;
 
+import jakarta.enterprise.context.NormalScope;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import jakarta.enterprise.context.NormalScope;
-
 /**
- * <p>The jakarta.transaction.TransactionScoped annotation provides the ability to
- * specify a standard CDI scope to define bean instances whose lifecycle is
- * scoped to the currently active Jakarta Transactions transaction. This annotation has no effect
- * on classes which have non-contextual references such those defined as managed
- * beans by the Jakarta EE specification.</p>
- * The transaction scope is active when the return from a call to
- * <code>UserTransaction.getStatus</code> or
- * <code>TransactionManager.getStatus</code>
- * is one of the following states:
+ * <p>
+ * The jakarta.transaction.TransactionScoped annotation provides the ability to specify a standard CDI scope to define
+ * bean instances whose lifecycle is scoped to the currently active Jakarta Transactions transaction. This annotation
+ * has no effect on classes which have non-contextual references such those defined as managed beans by the Jakarta EE
+ * specification.
+ * </p>
+ * The transaction scope is active when the return from a call to <code>UserTransaction.getStatus</code> or
+ * <code>TransactionManager.getStatus</code> is one of the following states:
  * <ul>
  * <li>Status.STATUS_ACTIVE
  * <li>Status.STATUS_MARKED_ROLLBACK
@@ -41,27 +39,24 @@ import jakarta.enterprise.context.NormalScope;
  * <li>Status.STATUS_COMMITTING
  * <li>Status.STATUS_ROLLING_BACK
  * </ul>
- * <p>It is not intended that the term "active" as defined here in relation to the
- * TransactionScoped annotation should also apply to its use in relation to
- * transaction context, lifecycle, etc. mentioned elsewhere in this
- * specification. The object with this annotation will be associated with the
- * current active Jakarta Transactions transaction when the object is used. This association must
- * be retained through any transaction suspend or resume calls as well as any
- * <code>Synchronization.beforeCompletion</code> callbacks. Any
- * <code>Synchronization.afterCompletion</code> methods will be invoked in an undefined
- * context. The way in which the Jakarta Transactions transaction is begun and completed
- * (for example via UserTransaction, Transactional interceptor, etc.) is of no consequence.
- * The contextual references used across different Jakarta Transactions transactions are distinct.
- * Refer to the CDI specification for more details on contextual references.
- * A <code>jakarta.enterprise.context.ContextNotActiveException</code>
- * will be thrown if an object with this annotation is used when the
- * transaction context is not active.</p>
+ * <p>
+ * It is not intended that the term "active" as defined here in relation to the TransactionScoped annotation should also
+ * apply to its use in relation to transaction context, lifecycle, etc. mentioned elsewhere in this specification. The
+ * object with this annotation will be associated with the current active Jakarta Transactions transaction when the
+ * object is used. This association must be retained through any transaction suspend or resume calls as well as any
+ * <code>Synchronization.beforeCompletion</code> callbacks. Any <code>Synchronization.afterCompletion</code> methods
+ * will be invoked in an undefined context. The way in which the Jakarta Transactions transaction is begun and completed
+ * (for example via UserTransaction, Transactional interceptor, etc.) is of no consequence. The contextual references
+ * used across different Jakarta Transactions transactions are distinct. Refer to the CDI specification for more details
+ * on contextual references. A <code>jakarta.enterprise.context.ContextNotActiveException</code> will be thrown if an
+ * object with this annotation is used when the transaction context is not active.
+ * </p>
  *
- *  @version Jakarta Transactions 2.0
- *  @since JTA 1.2
+ * @version Jakarta Transactions 2.0
+ * @since JTA 1.2
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
-@NormalScope(passivating=true)
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD })
+@NormalScope(passivating = true)
 public @interface TransactionScoped {
 }

--- a/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
+++ b/api/src/main/java/jakarta/transaction/TransactionSynchronizationRegistry.java
@@ -17,21 +17,18 @@
 package jakarta.transaction;
 
 /**
- * This interface is intended for use by system level application server
- * components such as persistence managers, resource adapters, as well as
- * Jakarta Enterprise Beans and Web application components. This provides the ability to
- * register synchronization objects with special ordering semantics,
- * associate resource objects with the current transaction, get the
- * transaction context of the current transaction, get current transaction
- * status, and mark the current transaction for rollback.
+ * This interface is intended for use by system level application server components such as persistence managers,
+ * resource adapters, as well as Jakarta Enterprise Beans and Web application components. This provides the ability to
+ * register synchronization objects with special ordering semantics, associate resource objects with the current
+ * transaction, get the transaction context of the current transaction, get current transaction status, and mark the
+ * current transaction for rollback.
  *
- * This interface is implemented by the application server by a
- * stateless service object. The same object can be used by any number of
- * components with thread safety.
+ * This interface is implemented by the application server by a stateless service object. The same object can be used by
+ * any number of components with thread safety.
  *
- * <P>In standard application server environments, an instance
- * implementing this interface can be looked up by a standard name via JNDI.
- * The standard name is java:comp/TransactionSynchronizationRegistry.
+ * <P>
+ * In standard application server environments, an instance implementing this interface can be looked up by a standard
+ * name via JNDI. The standard name is java:comp/TransactionSynchronizationRegistry.
  *
  * @version Jakarta Transactions 2.0
  * @since JTA 1.1
@@ -39,45 +36,36 @@ package jakarta.transaction;
 public interface TransactionSynchronizationRegistry {
 
     /**
-     * Return an opaque object to represent the transaction bound to the
-     * current thread at the time this method is called. This object
-     * overrides hashCode and equals to allow its use as the key in a
-     * hashMap for use by the caller. If there is no transaction currently
-     * active, return null.
-     * 
-     * <P>This object will return the same hashCode and compare equal to
-     * all other objects returned by calling this method
-     * from any component executing in the same transaction context in the
-     * same application server.
-     * 
-     * <P>The toString method returns a String that might be usable by a
-     * human reader to usefully understand the transaction context. The
-     * toString result is otherwise not defined. Specifically, there is no
-     * forward or backward compatibility guarantee of the results of
-     * toString.
-     * 
-     * <P>The object is not necessarily serializable, and has no defined
-     * behavior outside the virtual machine whence it was obtained.
+     * Return an opaque object to represent the transaction bound to the current thread at the time this method is called.
+     * This object overrides hashCode and equals to allow its use as the key in a hashMap for use by the caller. If there is
+     * no transaction currently active, return null.
      *
-     * @return an opaque object representing the transaction bound to the 
-     * current thread at the time this method is called.
+     * <P>
+     * This object will return the same hashCode and compare equal to all other objects returned by calling this method from
+     * any component executing in the same transaction context in the same application server.
+     *
+     * <P>
+     * The toString method returns a String that might be usable by a human reader to usefully understand the transaction
+     * context. The toString result is otherwise not defined. Specifically, there is no forward or backward compatibility
+     * guarantee of the results of toString.
+     *
+     * <P>
+     * The object is not necessarily serializable, and has no defined behavior outside the virtual machine whence it was
+     * obtained.
+     *
+     * @return an opaque object representing the transaction bound to the current thread at the time this method is called.
      *
      * @since JTA 1.1
      */
     Object getTransactionKey();
-    
+
     /**
-     * Add or replace an object in the Map of resources being managed for
-     * the transaction bound to the current thread at the time this 
-     * method is called. The supplied key should be of an caller-
-     * defined class so as not to conflict with other users. The class
-     * of the key must guarantee that the hashCode and equals methods are
-     * suitable for use as keys in a map. The key and value are not examined
-     * or used by the implementation. The general contract of this method
-     * is that of {@link java.util.Map#put(Object, Object)} for a Map that
-     * supports non-null keys and null values. For example, 
-     * if there is already an value associated with the key, it is replaced 
-     * by the value parameter. 
+     * Add or replace an object in the Map of resources being managed for the transaction bound to the current thread at the
+     * time this method is called. The supplied key should be of an caller- defined class so as not to conflict with other
+     * users. The class of the key must guarantee that the hashCode and equals methods are suitable for use as keys in a
+     * map. The key and value are not examined or used by the implementation. The general contract of this method is that of
+     * {@link java.util.Map#put(Object, Object)} for a Map that supports non-null keys and null values. For example, if
+     * there is already an value associated with the key, it is replaced by the value parameter.
      *
      * @param key the key for the Map entry.
      * @param value the value for the Map entry.
@@ -87,18 +75,13 @@ public interface TransactionSynchronizationRegistry {
      * @since JTA 1.1
      */
     void putResource(Object key, Object value);
-    
+
     /**
-     * Get an object from the Map of resources being managed for
-     * the transaction bound to the current thread at the time this 
-     * method is called. The key should have been supplied earlier
-     * by a call to putResouce in the same transaction. If the key 
-     * cannot be found in the current resource Map, null is returned.
-     * The general contract of this method
-     * is that of {@link java.util.Map#get(Object)} for a Map that
-     * supports non-null keys and null values. For example, 
-     * the returned value is null if there is no entry for the parameter
-     * key or if the value associated with the key is actually null.
+     * Get an object from the Map of resources being managed for the transaction bound to the current thread at the time
+     * this method is called. The key should have been supplied earlier by a call to putResouce in the same transaction. If
+     * the key cannot be found in the current resource Map, null is returned. The general contract of this method is that of
+     * {@link java.util.Map#get(Object)} for a Map that supports non-null keys and null values. For example, the returned
+     * value is null if there is no entry for the parameter key or if the value associated with the key is actually null.
      *
      * @param key the key for the Map entry.
      * @return the value associated with the key.
@@ -110,37 +93,29 @@ public interface TransactionSynchronizationRegistry {
     Object getResource(Object key);
 
     /**
-     * Register a Synchronization instance with special ordering
-     * semantics. Its beforeCompletion will be called after all 
-     * SessionSynchronization beforeCompletion callbacks and callbacks 
-     * registered directly with the Transaction, but before the 2-phase
-     * commit process starts. Similarly, the afterCompletion
-     * callback will be called after 2-phase commit completes but before
-     * any SessionSynchronization and Transaction afterCompletion callbacks.
-     * 
-     * <P>The beforeCompletion callback will be invoked in the transaction
-     * context of the transaction bound to the current thread at the time 
-     * this method is called. 
-     * Allowable methods include access to resources,
-     * e.g. Connectors. No access is allowed to "user components" (e.g. timer
-     * services or bean methods), as these might change the state of data
-     * being managed by the caller, and might change the state of data that
-     * has already been flushed by another caller of 
-     * registerInterposedSynchronization. 
-     * The general context is the component
-     * context of the caller of registerInterposedSynchronization.
-     * 
-     * <P>The afterCompletion callback will be invoked in an undefined 
-     * context. No access is permitted to "user components"
-     * as defined above. Resources can be closed but no transactional
-     * work can be performed with them.
-     * 
-     * <P>If this method is invoked without an active transaction context, an
-     * IllegalStateException is thrown.
+     * Register a Synchronization instance with special ordering semantics. Its beforeCompletion will be called after all
+     * SessionSynchronization beforeCompletion callbacks and callbacks registered directly with the Transaction, but before
+     * the 2-phase commit process starts. Similarly, the afterCompletion callback will be called after 2-phase commit
+     * completes but before any SessionSynchronization and Transaction afterCompletion callbacks.
      *
-     * <P>If this method is invoked after the two-phase commit processing has
-     * started, an IllegalStateException is thrown.
-     * 
+     * <P>
+     * The beforeCompletion callback will be invoked in the transaction context of the transaction bound to the current
+     * thread at the time this method is called. Allowable methods include access to resources, e.g. Connectors. No access
+     * is allowed to "user components" (e.g. timer services or bean methods), as these might change the state of data being
+     * managed by the caller, and might change the state of data that has already been flushed by another caller of
+     * registerInterposedSynchronization. The general context is the component context of the caller of
+     * registerInterposedSynchronization.
+     *
+     * <P>
+     * The afterCompletion callback will be invoked in an undefined context. No access is permitted to "user components" as
+     * defined above. Resources can be closed but no transactional work can be performed with them.
+     *
+     * <P>
+     * If this method is invoked without an active transaction context, an IllegalStateException is thrown.
+     *
+     * <P>
+     * If this method is invoked after the two-phase commit processing has started, an IllegalStateException is thrown.
+     *
      * @param sync the Synchronization instance.
      * @exception IllegalStateException if no transaction is active.
      *
@@ -149,22 +124,18 @@ public interface TransactionSynchronizationRegistry {
     void registerInterposedSynchronization(Synchronization sync);
 
     /**
-     * Return the status of the transaction bound to the
-     * current thread at the time this method is called.
-     * This is the result of executing TransactionManager.getStatus() in
-     * the context of the transaction bound to the current thread at the time
-     * this method is called.
+     * Return the status of the transaction bound to the current thread at the time this method is called. This is the
+     * result of executing TransactionManager.getStatus() in the context of the transaction bound to the current thread at
+     * the time this method is called.
      *
-     * @return the status of the transaction bound to the current thread 
-     * at the time this method is called.
+     * @return the status of the transaction bound to the current thread at the time this method is called.
      *
      * @since JTA 1.1
      */
     int getTransactionStatus();
 
     /**
-     * Set the rollbackOnly status of the transaction bound to the
-     * current thread at the time this method is called.
+     * Set the rollbackOnly status of the transaction bound to the current thread at the time this method is called.
      *
      * @exception IllegalStateException if no transaction is active.
      *
@@ -173,8 +144,7 @@ public interface TransactionSynchronizationRegistry {
     void setRollbackOnly();
 
     /**
-     * Get the rollbackOnly status of the transaction bound to the
-     * current thread at the time this method is called.
+     * Get the rollbackOnly status of the transaction bound to the current thread at the time this method is called.
      *
      * @return the rollbackOnly status.
      * @exception IllegalStateException if no transaction is active.

--- a/api/src/main/java/jakarta/transaction/Transactional.java
+++ b/api/src/main/java/jakarta/transaction/Transactional.java
@@ -21,138 +21,172 @@ import jakarta.interceptor.InterceptorBinding;
 import java.lang.annotation.*;
 
 /**
- * <p>The jakarta.transaction.Transactional annotation provides the application
- * the ability to declaratively control transaction boundaries on CDI managed beans, as
- * well as classes defined as managed beans by the Jakarta EE specification, at both the class
- * and method level where method level annotations override those at the class level.</p>
- * <p>See the Jakarta Enterprise Beans specification for restrictions on the use of @Transactional with Jakarta Enterprise Beans.</p>
- * <p>This support is provided via an implementation of CDI interceptors that conduct the
- * necessary suspending, resuming, etc. The Transactional interceptor interposes on business method
- * invocations only and not on lifecycle events. Lifecycle methods are invoked in an unspecified
- * transaction context.</p>
- * <p>If an attempt is made to call any method of the UserTransaction interface from within the
- * scope of a bean or method annotated with @Transactional and a Transactional.TxType other than
- * NOT_SUPPORTED or NEVER, an IllegalStateException must be thrown. The use of the UserTransaction
- * is allowed within life cycle events. The use of the TransactionSynchronizationRegistry is allowed
- * regardless of any @Transactional annotation.</p>
- * <p>The Transactional interceptors must have a priority of
- * Interceptor.Priority.PLATFORM_BEFORE+200.
- * Refer to the Interceptors specification for more details.</p>
- * <p>The TxType element of the annotation indicates whether a bean method is to be executed within
- * a transaction context.  TxType.REQUIRED is the default.     </p>
+ * <p>
+ * The jakarta.transaction.Transactional annotation provides the application the ability to declaratively control
+ * transaction boundaries on CDI managed beans, as well as classes defined as managed beans by the Jakarta EE
+ * specification, at both the class and method level where method level annotations override those at the class level.
+ * </p>
+ * <p>
+ * See the Jakarta Enterprise Beans specification for restrictions on the use of @Transactional with Jakarta Enterprise
+ * Beans.
+ * </p>
+ * <p>
+ * This support is provided via an implementation of CDI interceptors that conduct the necessary suspending, resuming,
+ * etc. The Transactional interceptor interposes on business method invocations only and not on lifecycle events.
+ * Lifecycle methods are invoked in an unspecified transaction context.
+ * </p>
+ * <p>
+ * If an attempt is made to call any method of the UserTransaction interface from within the scope of a bean or method
+ * annotated with @Transactional and a Transactional.TxType other than NOT_SUPPORTED or NEVER, an IllegalStateException
+ * must be thrown. The use of the UserTransaction is allowed within life cycle events. The use of the
+ * TransactionSynchronizationRegistry is allowed regardless of any @Transactional annotation.
+ * </p>
+ * <p>
+ * The Transactional interceptors must have a priority of Interceptor.Priority.PLATFORM_BEFORE+200. Refer to the
+ * Interceptors specification for more details.
+ * </p>
+ * <p>
+ * The TxType element of the annotation indicates whether a bean method is to be executed within a transaction context.
+ * TxType.REQUIRED is the default.
+ * </p>
  *
- * <p>By default checked exceptions do not result in the transactional interceptor marking the
- * transaction for rollback and instances of RuntimeException and its  subclasses do. This default
- * behavior can be modified by specifying exceptions that result in the interceptor marking the
- * transaction for rollback and/or exceptions that do not result in rollback.</p>
- * <p>The rollbackOn element can be set to indicate exceptions that must cause the interceptor to mark
- * the transaction for rollback.</p>
- * <p>Conversely, the dontRollbackOn element can be set to indicate
- * exceptions that must not cause the interceptor to mark the transaction for rollback.</p>
- * <p>When a class is specified for either of these elements, the designated behavior applies to subclasses
- * of that class as well. If both elements are specified, dontRollbackOn takes precedence.</p>
+ * <p>
+ * By default checked exceptions do not result in the transactional interceptor marking the transaction for rollback and
+ * instances of RuntimeException and its subclasses do. This default behavior can be modified by specifying exceptions
+ * that result in the interceptor marking the transaction for rollback and/or exceptions that do not result in rollback.
+ * </p>
+ * <p>
+ * The rollbackOn element can be set to indicate exceptions that must cause the interceptor to mark the transaction for
+ * rollback.
+ * </p>
+ * <p>
+ * Conversely, the dontRollbackOn element can be set to indicate exceptions that must not cause the interceptor to mark
+ * the transaction for rollback.
+ * </p>
+ * <p>
+ * When a class is specified for either of these elements, the designated behavior applies to subclasses of that class
+ * as well. If both elements are specified, dontRollbackOn takes precedence.
+ * </p>
  *
  * @version Jakarta Transactions 2.0
  * @since JTA 1.2
  */
 @Inherited
 @InterceptorBinding
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface Transactional {
 
     /**
-     * The TxType element of the Transactional annotation indicates whether a bean method
-     * is to be executed within a transaction context.
+     * The TxType element of the Transactional annotation indicates whether a bean method is to be executed within a
+     * transaction context.
+     *
      * @return TxType element
      */
     TxType value() default TxType.REQUIRED;
 
     /**
-     * The TxType element of the annotation indicates whether a bean method is to be
-     * executed within a transaction context where the values provide the following
-     * corresponding behavior.
+     * The TxType element of the annotation indicates whether a bean method is to be executed within a transaction context
+     * where the values provide the following corresponding behavior.
      *
      * @version Jakarta Transactions 2.0
      */
     public enum TxType {
         /**
-         *  <p>If called outside a transaction context, the interceptor must begin a new
-         *  Jakarta Transactions transaction, the managed bean method execution must then continue
-         *  inside this transaction context, and the transaction must be completed by
-         *  the interceptor.</p>
-         *  <p>If called inside a transaction context, the managed bean
-         *  method execution must then continue inside this transaction context.</p>
+         * <p>
+         * If called outside a transaction context, the interceptor must begin a new Jakarta Transactions transaction, the
+         * managed bean method execution must then continue inside this transaction context, and the transaction must be
+         * completed by the interceptor.
+         * </p>
+         * <p>
+         * If called inside a transaction context, the managed bean method execution must then continue inside this transaction
+         * context.
+         * </p>
          */
         REQUIRED,
 
         /**
-         *  <p>If called outside a transaction context, the interceptor must begin a new
-         *  Jakarta Transactions transaction, the managed bean method execution must then continue
-         *  inside this transaction context, and the transaction must be completed by
-         *  the interceptor.</p>
-         *  <p>If called inside a transaction context, the current transaction context must
-         *  be suspended, a new Jakarta Transactions transaction will begin, the managed bean method
-         *  execution must then continue inside this transaction context, the transaction
-         *  must be completed, and the previously suspended transaction must be resumed.</p>
+         * <p>
+         * If called outside a transaction context, the interceptor must begin a new Jakarta Transactions transaction, the
+         * managed bean method execution must then continue inside this transaction context, and the transaction must be
+         * completed by the interceptor.
+         * </p>
+         * <p>
+         * If called inside a transaction context, the current transaction context must be suspended, a new Jakarta Transactions
+         * transaction will begin, the managed bean method execution must then continue inside this transaction context, the
+         * transaction must be completed, and the previously suspended transaction must be resumed.
+         * </p>
          */
         REQUIRES_NEW,
 
         /**
-         *  <p>If called outside a transaction context, a TransactionalException with a
-         *  nested TransactionRequiredException must be thrown.</p>
-         *  <p>If called inside a transaction context, managed bean method execution will
-         *  then continue under that context.</p>
+         * <p>
+         * If called outside a transaction context, a TransactionalException with a nested TransactionRequiredException must be
+         * thrown.
+         * </p>
+         * <p>
+         * If called inside a transaction context, managed bean method execution will then continue under that context.
+         * </p>
          */
         MANDATORY,
 
         /**
-         *  <p>If called outside a transaction context, managed bean method execution
-         *  must then continue outside a transaction context.</p>
-         *  <p>If called inside a transaction context, the managed bean method execution
-         *  must then continue inside this transaction context.</p>
+         * <p>
+         * If called outside a transaction context, managed bean method execution must then continue outside a transaction
+         * context.
+         * </p>
+         * <p>
+         * If called inside a transaction context, the managed bean method execution must then continue inside this transaction
+         * context.
+         * </p>
          */
         SUPPORTS,
 
         /**
-         *  <p>If called outside a transaction context, managed bean method execution
-         *  must then continue outside a transaction context.</p>
-         *  <p>If called inside a transaction context, the current transaction context must
-         *  be suspended, the managed bean method execution must then continue
-         *  outside a transaction context, and the previously suspended transaction
-         *  must be resumed by the interceptor that suspended it after the method
-         *  execution has completed.</p>
+         * <p>
+         * If called outside a transaction context, managed bean method execution must then continue outside a transaction
+         * context.
+         * </p>
+         * <p>
+         * If called inside a transaction context, the current transaction context must be suspended, the managed bean method
+         * execution must then continue outside a transaction context, and the previously suspended transaction must be resumed
+         * by the interceptor that suspended it after the method execution has completed.
+         * </p>
          */
         NOT_SUPPORTED,
 
         /**
-         *  <p>If called outside a transaction context, managed bean method execution
-         *  must then continue outside a transaction context.</p>
-         *  <p>If called inside a transaction context, a TransactionalException with
-         *  a nested InvalidTransactionException must be thrown.</p>
+         * <p>
+         * If called outside a transaction context, managed bean method execution must then continue outside a transaction
+         * context.
+         * </p>
+         * <p>
+         * If called inside a transaction context, a TransactionalException with a nested InvalidTransactionException must be
+         * thrown.
+         * </p>
          */
         NEVER
     }
 
     /**
-     * The rollbackOn element can be set to indicate exceptions that must cause
-     *  the interceptor to mark the transaction for rollback. Conversely, the dontRollbackOn
-     *  element can be set to indicate exceptions that must not cause the interceptor to mark
-     *  the transaction for rollback. When a class is specified for either of these elements,
-     *  the designated behavior applies to subclasses of that class as well. If both elements
-     *  are specified, dontRollbackOn takes precedence.
+     * The rollbackOn element can be set to indicate exceptions that must cause the interceptor to mark the transaction for
+     * rollback. Conversely, the dontRollbackOn element can be set to indicate exceptions that must not cause the
+     * interceptor to mark the transaction for rollback. When a class is specified for either of these elements, the
+     * designated behavior applies to subclasses of that class as well. If both elements are specified, dontRollbackOn takes
+     * precedence.
+     *
      * @return Class[] of Exceptions
      */
     @Nonbinding
     public Class[] rollbackOn() default {};
 
     /**
-     * The dontRollbackOn element can be set to indicate exceptions that must not cause
-     *  the interceptor to mark the transaction for rollback. Conversely, the rollbackOn element
-     *  can be set to indicate exceptions that must cause the interceptor to mark the transaction
-     *  for rollback. When a class is specified for either of these elements,
-     *  the designated behavior applies to subclasses of that class as well. If both elements
-     *  are specified, dontRollbackOn takes precedence.
+     * The dontRollbackOn element can be set to indicate exceptions that must not cause the interceptor to mark the
+     * transaction for rollback. Conversely, the rollbackOn element can be set to indicate exceptions that must cause the
+     * interceptor to mark the transaction for rollback. When a class is specified for either of these elements, the
+     * designated behavior applies to subclasses of that class as well. If both elements are specified, dontRollbackOn takes
+     * precedence.
+     *
      * @return Class[] of Exceptions
      */
     @Nonbinding

--- a/api/src/main/java/jakarta/transaction/TransactionalException.java
+++ b/api/src/main/java/jakarta/transaction/TransactionalException.java
@@ -18,17 +18,13 @@ package jakarta.transaction;
 
 /**
  *
- * The TransactionalException thrown from the Transactional interceptors
- *  implementation contains the original exception as its nested exception
- *  and is a RuntimeException, therefore, by default any
- *  transaction that was started as a result of a Transactional annotation
- *  earlier in the call stream will be marked for rollback as a result of
- *  the TransactionalException being thrown by the Transactional interceptor
- *  of the second bean. For example if a transaction is begun as a result of
- *  a call to a bean annotated with Transactional(TxType.REQUIRED) and this
- *  bean in turn calls a second bean annotated with
- *  Transactional(TxType.NEVER), the transaction begun by the first bean
- *  will be marked for rollback.
+ * The TransactionalException thrown from the Transactional interceptors implementation contains the original exception
+ * as its nested exception and is a RuntimeException, therefore, by default any transaction that was started as a result
+ * of a Transactional annotation earlier in the call stream will be marked for rollback as a result of the
+ * TransactionalException being thrown by the Transactional interceptor of the second bean. For example if a transaction
+ * is begun as a result of a call to a bean annotated with Transactional(TxType.REQUIRED) and this bean in turn calls a
+ * second bean annotated with Transactional(TxType.NEVER), the transaction begun by the first bean will be marked for
+ * rollback.
  *
  * @version Jakarta Transactions 2.0
  * @since JTA 1.2

--- a/api/src/main/java/jakarta/transaction/UserTransaction.java
+++ b/api/src/main/java/jakarta/transaction/UserTransaction.java
@@ -20,8 +20,8 @@ import java.lang.IllegalStateException;
 import java.lang.SecurityException;
 
 /**
- * The UserTransaction interface defines the methods that allow an
- * application to explicitly manage transaction boundaries.
+ * The UserTransaction interface defines the methods that allow an application to explicitly manage transaction
+ * boundaries.
  *
  * @version Jakarta Transactions 2.0
  */
@@ -30,71 +30,57 @@ public interface UserTransaction {
     /**
      * Create a new transaction and associate it with the current thread.
      *
-     * @exception NotSupportedException Thrown if the thread is already
-     *    associated with a transaction and the Transaction Manager
-     *    implementation does not support nested transactions.
+     * @exception NotSupportedException Thrown if the thread is already associated with a transaction and the Transaction
+     * Manager implementation does not support nested transactions.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     void begin() throws NotSupportedException, SystemException;
 
     /**
-     * Complete the transaction associated with the current thread. When this
-     * method completes, the thread is no longer associated with a transaction.
+     * Complete the transaction associated with the current thread. When this method completes, the thread is no longer
+     * associated with a transaction.
      *
-     * @exception RollbackException Thrown to indicate that
-     *    the transaction has been rolled back rather than committed.
+     * @exception RollbackException Thrown to indicate that the transaction has been rolled back rather than committed.
      *
-     * @exception HeuristicMixedException Thrown to indicate that a heuristic
-     *    decision was made and that some relevant updates have been committed
-     *    while others have been rolled back.
+     * @exception HeuristicMixedException Thrown to indicate that a heuristic decision was made and that some relevant
+     * updates have been committed while others have been rolled back.
      *
-     * @exception HeuristicRollbackException Thrown to indicate that a
-     *    heuristic decision was made and that all relevant updates have been
-     *    rolled back.
+     * @exception HeuristicRollbackException Thrown to indicate that a heuristic decision was made and that all relevant
+     * updates have been rolled back.
      *
-     * @exception SecurityException Thrown to indicate that the thread is
-     *    not allowed to commit the transaction.
+     * @exception SecurityException Thrown to indicate that the thread is not allowed to commit the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
-    */
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
+     */
     void commit() throws RollbackException,
-	HeuristicMixedException, HeuristicRollbackException, SecurityException,
-	IllegalStateException, SystemException;
+            HeuristicMixedException, HeuristicRollbackException, SecurityException,
+            IllegalStateException, SystemException;
 
     /**
-     * Roll back the transaction associated with the current thread. When this
-     * method completes, the thread is no longer associated with a transaction.
+     * Roll back the transaction associated with the current thread. When this method completes, the thread is no longer
+     * associated with a transaction.
      *
-     * @exception SecurityException Thrown to indicate that the thread is
-     *    not allowed to roll back the transaction.
+     * @exception SecurityException Thrown to indicate that the thread is not allowed to roll back the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     void rollback() throws IllegalStateException, SecurityException,
-        SystemException;
+            SystemException;
 
     /**
-     * Modify the transaction associated with the current thread such that
-     * the only possible outcome of the transaction is to roll back the
-     * transaction.
+     * Modify the transaction associated with the current thread such that the only possible outcome of the transaction is
+     * to roll back the transaction.
      *
-     * @exception IllegalStateException Thrown if the current thread is
-     *    not associated with a transaction.
+     * @exception IllegalStateException Thrown if the current thread is not associated with a transaction.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     void setRollbackOnly() throws IllegalStateException, SystemException;
@@ -102,29 +88,25 @@ public interface UserTransaction {
     /**
      * Obtain the status of the transaction associated with the current thread.
      *
-     * @return The transaction status. If no transaction is associated with
-     *    the current thread, this method returns the Status.NoTransaction
-     *    value.
+     * @return The transaction status. If no transaction is associated with the current thread, this method returns the
+     * Status.NoTransaction value.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     int getStatus() throws SystemException;
 
     /**
-     * Modify the timeout value that is associated with transactions started
-     * by the current thread with the begin method.
+     * Modify the timeout value that is associated with transactions started by the current thread with the begin method.
      *
-     * <p> If an application has not called this method, the transaction
-     * service uses some default value for the transaction timeout.
+     * <p>
+     * If an application has not called this method, the transaction service uses some default value for the transaction
+     * timeout.
      *
-     * @param seconds The value of the timeout in seconds. If the value is zero,
-     *        the transaction service restores the default value. If the value
-     *        is negative a SystemException is thrown.
+     * @param seconds The value of the timeout in seconds. If the value is zero, the transaction service restores the
+     * default value. If the value is negative a SystemException is thrown.
      *
-     * @exception SystemException Thrown if the transaction manager
-     *    encounters an unexpected error condition.
+     * @exception SystemException Thrown if the transaction manager encounters an unexpected error condition.
      *
      */
     void setTransactionTimeout(int seconds) throws SystemException;

--- a/api/src/main/java/jakarta/transaction/package.html
+++ b/api/src/main/java/jakarta/transaction/package.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
-<head>
-<!--
+    <head>
+        <!--
 
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
 
@@ -18,19 +18,10 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-
-</head>
-<body bgcolor="white">
-
-Provides the API that defines the contract between the transaction 
-manager and the various parties involved in a distributed transaction 
-namely : resource manager, application, and application server. 
-The implementation of this API is provided by the application 
-server vendor and the resource manager driver vendor.
-
-<br>
-<p>Jakarta Transactions 2.0.
-
-</body>
+    </head>
+    <body bgcolor="white">
+        Provides the API that defines the contract between the transaction manager and the various parties involved in a distributed transaction namely : resource manager, application, and application server. The implementation of this API is provided by the application server vendor and the resource manager driver vendor.
+        <br>
+        <p>Jakarta Transactions 2.0.</p>
+    </body>
 </html>
-


### PR DESCRIPTION
Added a code formatter and use the Eclipse formatting options. To validate you can use -Dvalidate-format.

Thanks to code you can find in https://github.com/jakartaee/servlet/blob/3435a0ba4dc6d1e3409a6f7118970a00ff0c3d23/.github/workflows/maven.yml for the CI side (not visible here) and https://github.com/jakartaee/servlet/tree/3435a0ba4dc6d1e3409a6f7118970a00ff0c3d23/api/etc/config

I have checked and believe the format to be equivalent to what I obtained from https://raw.githubusercontent.com/eclipse-ee4j/ee4j/refs/heads/main/codestyle/ee4j-eclipse-formatting.xml earlier today (UK time)